### PR TITLE
Converted datetime strings to datetime objects

### DIFF
--- a/shellhub/__init__.py
+++ b/shellhub/__init__.py
@@ -1,5 +1,5 @@
 # Increment versions here according to SemVer
-__version__ = "0.2.4"
+__version__ = "0.3.0"
 
 from .models.device import ShellHubDevice, ShellHubDeviceInfo
 from .models.base import ShellHub

--- a/shellhub/models/device.py
+++ b/shellhub/models/device.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -40,12 +41,12 @@ class ShellHubDevice:
     info: ShellHubDeviceInfo
     public_key: str
     tenant_id: str
-    last_seen: str
+    last_seen: datetime
     online: bool
     namespace: str
     status: str
-    status_updated_at: str
-    created_at: str
+    status_updated_at: datetime
+    created_at: datetime
     remote_addr: str
     tags: List[str]
     acceptable: bool
@@ -59,15 +60,22 @@ class ShellHubDevice:
         self.info = ShellHubDeviceInfo(device_json["info"])
         self.public_key = device_json["public_key"]
         self.tenant_id = device_json["tenant_id"]
-        self.last_seen = device_json["last_seen"]
+        self.last_seen = self._safe_isoformat_to_datetime(device_json["last_seen"])
         self.online = device_json["online"]
         self.namespace = device_json["namespace"]
         self.status = device_json["status"]
-        self.status_updated_at = device_json["status_updated_at"]
-        self.created_at = device_json["created_at"]
+        self.status_updated_at = self._safe_isoformat_to_datetime(device_json["status_updated_at"])
+        self.created_at = self._safe_isoformat_to_datetime(device_json["created_at"])
         self.remote_addr = device_json["remote_addr"]
         self.tags = device_json["tags"]
         self.acceptable = device_json["acceptable"]
+
+    @staticmethod
+    def _safe_isoformat_to_datetime(date_string: str) -> datetime:
+        try:
+            return datetime.fromisoformat(date_string)
+        except ValueError as e:
+            raise ShellHubApiError(f"Invalid date string: {date_string} (Couldn't convert to datetime)") from e
 
     def delete(self) -> bool:
         """

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone
 
 import pytest
 
@@ -106,6 +107,7 @@ class TestGetDevice:
         }
         requests_mock.get(f"{MOCKED_DOMAIN_URL}/api/devices/1", json=mock_response)
         device = shellhub.get_device("1")
+        origin_time = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
 
         assert device.uid == "1"
         assert device.name == "default"
@@ -120,12 +122,12 @@ class TestGetDevice:
             == "-----BEGIN RSA PUBLIC KEY-----\nxxx\nxxx\nxxx\nxxx\nxxx\nxxx\n-----END RSA PUBLIC KEY-----\n"
         )
         assert device.tenant_id == "1"
-        assert device.last_seen == datetime.fromisoformat("1970-01-01T00:00:00Z")
+        assert device.last_seen == origin_time
         assert device.online
         assert device.namespace == "dev"
         assert device.status == "accepted"
-        assert device.status_updated_at == datetime.fromisoformat("1970-01-01T00:00:00Z")
-        assert device.created_at == datetime.fromisoformat("1970-01-01T00:00:00Z")
+        assert device.status_updated_at == origin_time
+        assert device.created_at == origin_time
         assert device.remote_addr == "0.0.0.0"
         assert device.tags == []
         assert not device.acceptable


### PR DESCRIPTION
Here I have used datetime module. By which we can take inputs in date format.
![image](https://github.com/Seluj78/shellhub-python/assets/139901494/f7b1e8c7-b802-4b38-9d4d-5470027f9616)
![image](https://github.com/Seluj78/shellhub-python/assets/139901494/03aacb2f-1211-4ca1-8b3c-905b53f095dd)

Fixes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Improved the handling of date and time for device attributes to enhance accuracy and performance.
    - Updated version from "0.2.0" to "0.3.0" in the application.
- **Tests**
    - Added import statement for `datetime` module in test files.
    - Changed date string comparisons to `datetime` objects in test files for improved testing accuracy.
    - Added a new test method to handle incorrect datetime formats in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->